### PR TITLE
Skip mapping generation when new_text and text are similar

### DIFF
--- a/src/quran_transcript/phonetics/conv_base_operation.py
+++ b/src/quran_transcript/phonetics/conv_base_operation.py
@@ -597,6 +597,9 @@ def sub_with_mapping(
 
     # Apply the regex substitution
     new_text = re.sub(pattern, repl, text)
+    # If no changes occur, then skip remapping
+    if new_text == text and mappings is not None:
+        return text, mappings
     new_mappings = get_mappings(text, new_text, mappings, tajweed_rule=tajweed_rule)
     return new_text, new_mappings
 


### PR DESCRIPTION
In the sub_with_mappings function, the function would run on every input by first running `re.sub` to generate the new text and then generating the mapping between the old and the new text using get_mappings.

A simple guard was added to avoid the overhead computations which checks if the new and old texts are the same. This will avoid unnecessary `get_mappings` calls and improve the performance.

I ran `test_sub_with_mapping.py` and the time it took before the changes was around ~2 minutes. After adding that simple guard, it went down to 40 seconds.

Reran the test multiple times and other tests to verify the consistency of the results.

